### PR TITLE
Updated atomic_charges for chelpg

### DIFF
--- a/sphinx/data_notes.rst
+++ b/sphinx/data_notes.rst
@@ -55,7 +55,7 @@ atomcharges
 
 The attribute ``atomcharges`` contains the atomic partial charges as taken from the output file. Since these charges are arbitrary and depend on the details of a population analysis, this attribute is dictionary containing any number of various atomic charges. The keys in this dictionary are strings naming the population analysis, and the values are arrays of rank 1 and contain the actual charges.
 
-Currently, cclib parses Mulliken, Löwdin and NPA charges, whose respective dictionary keys are ``mulliken``, ``lowdin`` and ``natural``.
+Currently, cclib parses Mulliken, Löwdin, NPA and CHELPG charges, whose respective dictionary keys are ``mulliken``, ``lowdin``, ``natural`` and ``chelpg``.
 
 Note that in practice these may differ somewhat from the values cclib calculates in the various calculation methods.
 


### PR DESCRIPTION
Not sure if I should mention this is only for ORCA currently?